### PR TITLE
chore(ci): migrate `google-github-actions/release-please-action` to `googleapis/release-please-action`

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -18,7 +18,7 @@ jobs:
 
     runs-on: ubuntu-latest
     steps:
-      - uses: google-github-actions/release-please-action@v4
+      - uses: googleapis/release-please-action@v4
         id: release
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Background

`google-github-actions/release-please-action` is deprecated, the recommended way is `googleapis/release-please-action`