### PR TITLE
feat: add curry and partial application utilities

### DIFF
--- a/src/Curry.test.ts
+++ b/src/Curry.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, test } from "bun:test"
+
+import { curry, partial } from "./Curry.ts"
+
+describe("curry", () => {
+  test("should convert a binary function into nested unary calls", () => {
+    const add = (a: number, b: number) => a + b
+    const curried = curry(add)
+    expect(curried(1)(2)).toBe(3)
+  })
+
+  test("should convert a ternary function correctly", () => {
+    const volume = (l: number, w: number, h: number) => l * w * h
+    const curried = curry(volume)
+    expect(curried(2)(3)(4)).toBe(24)
+  })
+
+  test("should maintain correct types", () => {
+    const concat = (a: string, b: string) => `${a}${b}`
+    const curried = curry(concat)
+    const result: string = curried("hello ")("world")
+    expect(result).toBe("hello world")
+  })
+})
+
+describe("partial", () => {
+  test("should fix the first argument", () => {
+    const add = (a: number, b: number) => a + b
+    const add10 = partial(add, 10)
+    expect(add10(5)).toBe(15)
+  })
+
+  test("should fix multiple arguments", () => {
+    const sum3 = (a: number, b: number, c: number) => a + b + c
+    const sum10and20 = partial(sum3, 10, 20)
+    expect(sum10and20(3)).toBe(33)
+  })
+
+  test("should maintain correct types", () => {
+    const greet = (greeting: string, name: string) => `${greeting}, ${name}!`
+    const hello = partial(greet, "Hello")
+    const result: string = hello("World")
+    expect(result).toBe("Hello, World!")
+  })
+})

--- a/src/Curry.ts
+++ b/src/Curry.ts
@@ -1,0 +1,58 @@
+/**
+ * Converts a function of N arguments into a chain of N unary functions.
+ * Transforms f(a, b, c) into f(a)(b)(c).
+ *
+ * @example
+ * const add = (a: number, b: number) => a + b
+ * const curriedAdd = curry(add)
+ * curriedAdd(1)(2) // 3
+ */
+export function curry<A, B, R>(fn: (a: A, b: B) => R): (a: A) => (b: B) => R
+export function curry<A, B, C, R>(
+  fn: (a: A, b: B, c: C) => R,
+): (a: A) => (b: B) => (c: C) => R
+export function curry<A, B, C, D, R>(
+  fn: (a: A, b: B, c: C, d: D) => R,
+): (a: A) => (b: B) => (c: C) => (d: D) => R
+export function curry(fn: (...args: unknown[]) => unknown) {
+  const arity = fn.length
+  const resolve =
+    (acc: unknown[]) =>
+    (arg: unknown): unknown => {
+      const args = [...acc, arg]
+      return args.length >= arity ? fn(...args) : resolve(args)
+    }
+  return resolve([])
+}
+
+/**
+ * Partially applies arguments to a function, returning a new function
+ * expecting the remaining arguments.
+ *
+ * @example
+ * const add = (a: number, b: number, c: number) => a + b + c
+ * const add10 = partial(add, 10)
+ * add10(5, 3) // 18
+ */
+export function partial<A, B, R>(fn: (a: A, b: B) => R, a: A): (b: B) => R
+export function partial<A, B, C, R>(
+  fn: (a: A, b: B, c: C) => R,
+  a: A,
+): (b: B, c: C) => R
+export function partial<A, B, C, R>(
+  fn: (a: A, b: B, c: C) => R,
+  a: A,
+  b: B,
+): (c: C) => R
+export function partial<A, B, C, D, R>(
+  fn: (a: A, b: B, c: C, d: D) => R,
+  a: A,
+  b: B,
+  c: C,
+): (d: D) => R
+export function partial(
+  fn: (...args: unknown[]) => unknown,
+  ...applied: unknown[]
+) {
+  return (...remaining: unknown[]) => fn(...applied, ...remaining)
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 export * from "./Container.ts"
+export * from "./Curry.ts"
 export * from "./Functor.ts"
 export * from "./Identity.ts"
 export * from "./Mapper.ts"


### PR DESCRIPTION
## Summary

Add `curry` and `partial` utilities — core FP tools for transforming multi-argument functions into composable unary functions.

### `curry`

Converts a function of N arguments into a chain of N unary functions:

```ts
const add = (a: number, b: number) => a + b
const curriedAdd = curry(add)
curriedAdd(1)(2) // 3
```

### `partial`

Partially applies leading arguments, returning a new function expecting the remaining ones:

```ts
const sum3 = (a: number, b: number, c: number) => a + b + c
const add10and20 = partial(sum3, 10, 20)
add10and20(3) // 33
```

Both use function overloads (2–4 params for `curry`, 1–3 applied args for `partial`) to provide strong type inference without requiring manual type annotations at call sites.