### PR TITLE
feat: add identity and constant combinators

### DIFF
--- a/src/Identity.test.ts
+++ b/src/Identity.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, test } from "bun:test"
+import { Functor } from "./Functor.ts"
+import { constant, identity } from "./Identity.ts"
+
+describe("identity", () => {
+  test("should return the same value for primitives", () => {
+    expect(identity(42)).toBe(42)
+    expect(identity("hello")).toBe("hello")
+    expect(identity(true)).toBe(true)
+  })
+
+  test("should return the same reference for objects", () => {
+    const obj = { a: 1 }
+    expect(identity(obj)).toBe(obj)
+  })
+})
+
+describe("constant", () => {
+  test("should always return the captured value regardless of input", () => {
+    const always42 = constant(42)
+    expect(always42("ignored")).toBe(42)
+    expect(always42(undefined)).toBe(42)
+    expect(always42(null)).toBe(42)
+    expect(always42(999)).toBe(42)
+  })
+})
+
+describe("functor identity law", () => {
+  test("functor.map(identity) should equal the original functor", () => {
+    const functor = new Functor(42)
+    const mapped = functor.map(identity)
+    expect(mapped.value).toEqual(functor.value)
+  })
+})

--- a/src/Identity.ts
+++ b/src/Identity.ts
@@ -1,0 +1,16 @@
+/**
+ * Returns its argument unchanged.
+ * This is a fundamental combinator used to verify functor and monad identity laws.
+ * @example identity(42) // 42
+ */
+export const identity = <const T>(value: T): T => value
+
+/**
+ * Returns a function that always returns the captured value, ignoring its argument.
+ * This is a fundamental combinator used to express and verify algebraic laws.
+ * @example constant(42)("ignored") // 42
+ */
+export const constant =
+  <const T>(value: T) =>
+  (_: unknown): T =>
+    value

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 export * from "./Container.ts"
 export * from "./Functor.ts"
+export * from "./Identity.ts"
 export * from "./Mapper.ts"
 export * from "./Monad.ts"
 export * from "./Option.ts"


### PR DESCRIPTION
## Summary

Add `identity` and `constant` — fundamental FP combinators used to express and verify algebraic laws (functor identity law, monad laws, etc.).

### Added

- **`identity<T>(value: T): T`** — returns its argument unchanged
- **`constant<T>(value: T): (_: unknown) => T`** — returns a function that always returns the captured value

### Tests

- `identity` preserves primitives and object references
- `constant` ignores its argument and always returns the captured value
- Functor identity law: `functor.map(identity)` equals the original functor

These combinators are educational building blocks that complement the existing Functor and Monad abstractions in this library.