### PR TITLE
feat: add Applicative functor

### DIFF
--- a/src/Applicative.test.ts
+++ b/src/Applicative.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, test } from "bun:test"
+
+import { Applicative } from "./Applicative.ts"
+import { identity } from "./Identity.ts"
+
+describe("Applicative", () => {
+  test("of wraps a value", () => {
+    const a = Applicative.of(42)
+    expect(a.value).toBe(42)
+  })
+
+  test("map transforms the value (functor behavior)", () => {
+    const a = Applicative.of(3)
+    const b = a.map((x) => x * 2)
+    expect(b.value).toBe(6)
+    expect(a.value).toBe(3)
+  })
+
+  test("ap applies a wrapped function to a wrapped value", () => {
+    const value = Applicative.of(5)
+    const fn = Applicative.of((x: number) => x + 1)
+    expect(value.ap(fn).value).toBe(6)
+  })
+
+  test("identity law: v.ap(Applicative.of(identity)) equals v", () => {
+    const v = Applicative.of(42)
+    const result = v.ap(Applicative.of(identity))
+    expect(result.value).toBe(v.value)
+  })
+
+  test("homomorphism law: Applicative.of(x).ap(Applicative.of(f)) equals Applicative.of(f(x))", () => {
+    const f = (x: number) => x * 3
+    const x = 7
+    const left = Applicative.of(x).ap(Applicative.of(f))
+    const right = Applicative.of(f(x))
+    expect(left.value).toBe(right.value)
+  })
+
+  test("combining two Applicatives with a curried function", () => {
+    const add = (a: number) => (b: number) => a + b
+    const a = Applicative.of(3)
+    const b = Applicative.of(4)
+    const result = b.ap(a.ap(Applicative.of(add)))
+    expect(result.value).toBe(7)
+  })
+
+  test("toString returns readable representation", () => {
+    const a = Applicative.of("hello")
+    expect(a.toString()).toBe("Applicative(hello)")
+  })
+})

--- a/src/Applicative.ts
+++ b/src/Applicative.ts
@@ -43,7 +43,9 @@ export class Applicative<const Value> extends Container<Value> {
    * @param {Applicative<Mapper<Value, Result>>} fn - An Applicative containing a function
    * @returns {Applicative<Result>}
    */
-  ap<const Result>(fn: Applicative<Mapper<Value, Result>>): Applicative<Result> {
+  ap<const Result>(
+    fn: Applicative<Mapper<Value, Result>>,
+  ): Applicative<Result> {
     return new Applicative(fn.value(this.value))
   }
 

--- a/src/Applicative.ts
+++ b/src/Applicative.ts
@@ -1,0 +1,57 @@
+import { Container } from "./Container.ts"
+
+import type { Mapper } from "./Mapper.ts"
+
+/**
+ * An Applicative functor — sits between Functor and Monad in the type class hierarchy.
+ *
+ * While a Functor lets you apply a plain function to a wrapped value (`map`),
+ * an Applicative lets you apply a *wrapped* function to a wrapped value (`ap`).
+ * This enables combining independent effects without sequencing them
+ * (unlike Monad, which sequences dependent effects via `flatMap`).
+ *
+ * Laws:
+ * - Identity: `v.ap(Applicative.of(identity))` ≡ `v`
+ * - Homomorphism: `Applicative.of(x).ap(Applicative.of(f))` ≡ `Applicative.of(f(x))`
+ * - Interchange: `Applicative.of(x).ap(u)` ≡ `u.ap(Applicative.of(f => f(x)))`
+ *
+ * @extends Container
+ */
+export class Applicative<const Value> extends Container<Value> {
+  /**
+   * Lifts a value into the Applicative context (pure/unit).
+   */
+  static of<const V>(value: V): Applicative<V> {
+    return new Applicative(value)
+  }
+
+  /**
+   * Maps the value of the container to a new value (functor behavior).
+   * @param {Mapper<Value, Result>} mapper
+   * @returns {Applicative<Result>}
+   */
+  map<const Result>(mapper: Mapper<Value, Result>): Applicative<Result> {
+    return new Applicative(mapper(this.value))
+  }
+
+  /**
+   * Applies a wrapped function to this wrapped value.
+   *
+   * Convention: `value.ap(wrappedFn)` — the receiver holds the value,
+   * and the argument holds the function to apply.
+   *
+   * @param {Applicative<Mapper<Value, Result>>} fn - An Applicative containing a function
+   * @returns {Applicative<Result>}
+   */
+  ap<const Result>(fn: Applicative<Mapper<Value, Result>>): Applicative<Result> {
+    return new Applicative(fn.value(this.value))
+  }
+
+  /**
+   * Returns a readable string of the container.
+   * @returns {string}
+   */
+  override toString(): string {
+    return `Applicative(${String(this.value)})`
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./Applicative.ts"
 export * from "./Container.ts"
 export * from "./Curry.ts"
 export * from "./Functor.ts"


### PR DESCRIPTION
## Summary

Adds the `Applicative` functor, which sits between `Functor` and `Monad` in the type class hierarchy.

While a **Functor** lets you apply a plain function to a wrapped value (`map`), an **Applicative** lets you apply a *wrapped* function to a wrapped value (`ap`). This enables combining independent effects without sequencing them (unlike Monad, which sequences dependent effects via `flatMap`).

## API

```typescript
// Lift a value into the Applicative context
Applicative.of(42)

// Functor map
Applicative.of(3).map(x => x * 2) // Applicative(6)

// Apply a wrapped function to a wrapped value
const value = Applicative.of(5)
const fn = Applicative.of((x: number) => x + 1)
value.ap(fn) // Applicative(6)

// Combine independent Applicatives with a curried function
const add = (a: number) => (b: number) => a + b
const a = Applicative.of(3)
const b = Applicative.of(4)
b.ap(a.ap(Applicative.of(add))) // Applicative(7)
```

## Tests

Covers basic usage plus the applicative laws (Identity, Homomorphism).