### PR TITLE
fix(ci): update GitHub Actions to support Node.js 24

### DIFF
--- a/.github/actions/cache/action.yaml
+++ b/.github/actions/cache/action.yaml
@@ -13,7 +13,7 @@ runs:
     - name: Store dependencies cache
       id: dependencies
       if: ${{ contains(inputs.scope, 'dependencies') }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: dependencies-${{ hashFiles('./bun.lockb') }}
         path: |
@@ -22,7 +22,7 @@ runs:
     - name: Store build cache
       id: build
       if: ${{ contains(inputs.scope, 'build') }}
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         key: build-${{ hashFiles('./src/**') }}
         path: |

--- a/.github/actions/setup-bun/action.yaml
+++ b/.github/actions/setup-bun/action.yaml
@@ -6,7 +6,7 @@ runs:
     - uses: ./.github/actions/cache
       with:
         scope: dependencies
-    - uses: oven-sh/setup-bun@v1
+    - uses: oven-sh/setup-bun@v2
       with:
         bun-version: latest
     - run: bun install

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
   ci-setup:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-bun
       - uses: ./.github/actions/build
       - uses: ./.github/actions/prevent-uncommit-changes
@@ -36,9 +36,9 @@ jobs:
       packages: write # to publish packages (npm publish)
       id-token: write # The OIDC ID token is used for authentication with JSR.
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
       - uses: ./.github/actions/setup-bun
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           registry-url: "https://npm.pkg.github.com"
       - uses: ./.github/actions/cache

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -24,17 +24,17 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           config-file: .github/config/release-please-config.json
           manifest-file: .github/config/.release-please-config.json
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v5
         with:
           fetch-depth: 0
           fetch-tags: true
-      - uses: oven-sh/setup-bun@v1
+      - uses: oven-sh/setup-bun@v2
         with:
           bun-version: latest
       - run: bun install
       - run: bun --bun run build
       - run: bun test
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v5
         with:
           registry-url: "https://npm.pkg.github.com"
         if: ${{ steps.release.outputs.release_created }}


### PR DESCRIPTION
GitHub Actions runners deprecated Node.js 20, causing warnings on every CI run that actions are being forced to run on Node.js 24. This bumps all affected actions to versions that natively target Node.js 24.

**Updated actions:**

- `actions/checkout` v4 -> v5
- `actions/cache` v4 -> v5
- `actions/setup-node` v4 -> v5
- `oven-sh/setup-bun` v1 -> v2

Changes span `ci.yml`, `semantic-release.yml`, and the shared composite actions (`cache/action.yaml`, `setup-bun/action.yaml`).